### PR TITLE
Fix keywords-in-logical-order error when there is rule keyword

### DIFF
--- a/src/rules/keywords-in-logical-order.js
+++ b/src/rules/keywords-in-logical-order.js
@@ -15,7 +15,7 @@ function run(feature) {
 
     let maxKeywordPosition = undefined;
 
-    node.steps.forEach((step) => {
+    node && node.steps.forEach((step) => {
       const keyword = gherkinUtils.getLanguageInsitiveKeyword(
         step,
         feature.language
@@ -23,7 +23,7 @@ function run(feature) {
       let keywordPosition = keywordList.indexOf(keyword);
 
       if (keywordPosition === -1) {
-        //   not found
+        // not found
         return;
       }
 


### PR DESCRIPTION
This PR is to fix below error when the feature file contains a statement with Rule keyword

```javascript
/Users/jimmyko/github/gherkin-lint/dist/rules/keywords-in-logical-order.js:17
    node.steps.forEach(step => {
         ^

TypeError: Cannot read properties of null (reading 'steps')
    at /Users/jimmyko/github/gherkin-lint/dist/rules/keywords-in-logical-order.js:17:10
    at Array.forEach (<anonymous>)
    at Object.run (/Users/jimmyko/github/gherkin-lint/dist/rules/keywords-in-logical-order.js:13:20)
    at /Users/jimmyko/github/gherkin-lint/dist/rules.js:46:26
    at Array.forEach (<anonymous>)
    at Object.runAllEnabledRules (/Users/jimmyko/github/gherkin-lint/dist/rules.js:41:22)
    at readAndParseFile.then.perFileErrors (/Users/jimmyko/github/gherkin-lint/dist/linter.js:74:29)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async Promise.all (index 0)
```