### PR TITLE
Fix false no scenarios error when there is Rule statement

### DIFF
--- a/src/rules/no-files-without-scenarios.js
+++ b/src/rules/no-files-without-scenarios.js
@@ -4,12 +4,23 @@ function filterScenarios(child) {
   return child.scenario != undefined;
 }
 
+function filterRule(child) {
+  return child.rule != undefined;
+}
+
+function reduceRuleChildren(acc, curr) {
+  curr.rule.children.forEach(function(child) {
+    acc.push(child);
+  });
+  return acc;
+}
+
 function run(feature) {
   if (!feature) {
     return [];
   }
   let errors = [];
-  if (!feature.children.some(filterScenarios)) {
+  if (!feature.children.some(filterScenarios) && !feature.children.filter(filterRule).reduce(reduceRuleChildren, []).some(filterScenarios)) {
     errors.push({
       message: 'Feature file does not have any Scenarios',
       rule   : rule,


### PR DESCRIPTION
This PR is to fix below incorrect error showing on the features with the Rule statements

```
Feature file does not have any Scenarios    no-files-without-scenarios
```